### PR TITLE
Fix fonsDrawDebug

### DIFF
--- a/src/fontstash.h
+++ b/src/fontstash.h
@@ -1255,6 +1255,8 @@ void fonsDrawDebug(struct FONScontext* stash, float x, float y)
 	fons__vertex(stash, x+0, y+0, 0, 0, 0xffffffff);
 	fons__vertex(stash, x+0, y+h, 0, 1, 0xffffffff);
 	fons__vertex(stash, x+w, y+h, 1, 1, 0xffffffff);
+
+	fons__flush(stash);
 }
 
 float fonsTextBounds(struct FONScontext* stash,


### PR DESCRIPTION
Otherwise the texture isn't actually drawn until the next time you call fonsDrawText or similar, which might be wrong if you've changed GL state or if you're relying on draw order relative to non-text stuff, or whatever.
