### PR TITLE
True type implementation

### DIFF
--- a/src/fontstash.h
+++ b/src/fontstash.h
@@ -153,7 +153,7 @@ typedef struct FONSttFontImpl FONSttFontImpl;
 
 static FT_Library ftLibrary;
 
-int fons__tt_init()
+int fons__tt_init(FONScontext *context)
 {
 	FT_Error ftError;
 	ftError = FT_Init_FreeType(&ftLibrary);


### PR DESCRIPTION
It seems that the signature of fons__tt_init weren't the same in the stb true type and free type. Just fixed that by adding a lazy FONScontext\* parameter.
