### PR TITLE
Fix bug with scaling fallback fonts

### DIFF
--- a/src/fontstash.h
+++ b/src/fontstash.h
@@ -1119,7 +1119,7 @@ static FONSglyph* fons__getGlyph(FONScontext* stash, FONSfont* font, unsigned in
 		// It is possible that we did not find a fallback glyph.
 		// In that case the glyph index 'g' is 0, and we'll proceed below and cache empty glyph.
 	}
-	scale = fons__tt_getPixelHeightScale(&renderFont->font, size);
+	scale = fons__tt_getPixelHeightScale(&font->font, size);
 	fons__tt_buildGlyphBitmap(&renderFont->font, g, size, scale, &advance, &lsb, &x0, &y0, &x1, &y1);
 	gw = x1-x0 + pad*2;
 	gh = y1-y0 + pad*2;


### PR DESCRIPTION
Example: 
![fallback_font_bug](https://user-images.githubusercontent.com/1093274/55335162-eaa6af80-549a-11e9-9ac4-d05e6768e851.png)

Code used to produce test image (modification of example.c):
```c
fontBold = fonsAddFont(fs, "sans-bold", "../example/TitilliumWeb-Regular.ttf");
int fallback = fonsAddFont(fs, "sans-bold", "../example/NotoSans-Regular.ttf");
fonsAddFallbackFont(fs, fontBold, fallback);

...

fonsSetSize(fs, 72.0f);
fonsSetFont(fs, fontBold);
fonsSetColor(fs, white);
fonsDrawText(fs, 100, 100, "English Русский",NULL);
```